### PR TITLE
修复顺序命名模式下同日期同期数（无上中下）文件重命名排序错误的问题

### DIFF
--- a/app/static/js/sort_file_by_name.js
+++ b/app/static/js/sort_file_by_name.js
@@ -194,6 +194,24 @@ function sortFileByName(file) {
                 sequence_number = parseInt(arabic_seq_match[1]);
             }
         }
+    } else {
+        // 如果没有上中下标记，检查是否有括号内的中文数字序号
+        // 匹配格式如：第2期（一）、第2期（二）等
+        let parentheses_chinese_match = filename.match(/[期集话部篇][（(]([一二三四五六七八九十百千万零两]+)[）)]/);
+        if (parentheses_chinese_match) {
+            let arabic_num = chineseToArabic(parentheses_chinese_match[1]);
+            if (arabic_num !== null) {
+                sequence_number = arabic_num;
+                segment_base = 1;  // 给一个基础值，确保有括号序号的文件能正确排序
+            }
+        } else {
+            // 匹配格式如：第2期(1)、第2期(2)等
+            let parentheses_arabic_match = filename.match(/[期集话部篇][（(](\d+)[）)]/);
+            if (parentheses_arabic_match) {
+                sequence_number = parseInt(parentheses_arabic_match[1]);
+                segment_base = 1;  // 给一个基础值，确保有括号序号的文件能正确排序
+            }
+        }
     }
 
     // 组合segment_value：基础值*1000 + 序号值，确保排序正确

--- a/quark_auto_save.py
+++ b/quark_auto_save.py
@@ -251,6 +251,22 @@ def sort_file_by_name(file):
             arabic_seq_match = re.search(r'[上中下][集期话部篇]?(\d+)', filename)
             if arabic_seq_match:
                 sequence_number = int(arabic_seq_match.group(1))
+    else:
+        # 如果没有上中下标记，检查是否有括号内的中文数字序号
+        # 匹配格式如：第2期（一）、第2期（二）等
+        parentheses_chinese_match = re.search(r'[期集话部篇][（(]([一二三四五六七八九十百千万零两]+)[）)]', filename)
+        if parentheses_chinese_match:
+            chinese_num = parentheses_chinese_match.group(1)
+            arabic_num = chinese_to_arabic(chinese_num)
+            if arabic_num is not None:
+                sequence_number = arabic_num
+                segment_base = 1  # 给一个基础值，确保有括号序号的文件能正确排序
+        else:
+            # 匹配格式如：第2期(1)、第2期(2)等
+            parentheses_arabic_match = re.search(r'[期集话部篇][（(](\d+)[）)]', filename)
+            if parentheses_arabic_match:
+                sequence_number = int(parentheses_arabic_match.group(1))
+                segment_base = 1  # 给一个基础值，确保有括号序号的文件能正确排序
 
     # 组合segment_value：基础值*1000 + 序号值，确保排序正确
     segment_value = segment_base * 1000 + sequence_number


### PR DESCRIPTION
1. 增强 Python 版本排序函数（quark_auto_save.py）
   - 新增括号内中文数字序号识别：第2期（一）、第2期（二）
   - 新增括号内阿拉伯数字序号识别：第2期(1)、第2期(2)
   - 为有括号序号的文件设置段落基础值，确保正确排序

2. 同步更新 JavaScript 版本排序函数（sort_file_by_name.js）
   - 保持前后端排序逻辑一致